### PR TITLE
Fix opam package name for httpaf-lwt-unix

### DIFF
--- a/httpaf-lwt-unix.opam
+++ b/httpaf-lwt-unix.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "httpaf-lwt"
+name: "httpaf-lwt-unix"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [
   "Anton Bachin <antonbachin@yahoo.com>"


### PR DESCRIPTION
Seems like right now the `httpaf-lwt-unix` package can't be pinned because of the name in the opam file.

This is a follow-up to https://github.com/inhabitedtype/httpaf/pull/124 which I think missed renaming the `name: ` field in the opam file